### PR TITLE
Improve Route53 dynamic DNS setup by moving to k8s-control node

### DIFF
--- a/phase-5-external-access-security.md
+++ b/phase-5-external-access-security.md
@@ -164,7 +164,19 @@ In AWS Console, create an IAM user with this policy:
 #### Create Dynamic DNS Update Script for Route53
 
 ```bash
-# Run these commands on your development machine or home router where AWS CLI is configured
+# SSH to k8s-control node (better than dev machine since it's always on)
+ssh k8sadmin@k8s-control
+
+# Install AWS CLI on k8s-control node
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+rm -rf awscliv2.zip aws/
+
+# Configure AWS credentials
+aws configure
+# Enter your Access Key ID, Secret Access Key, region (e.g., us-east-1)
+
 # Get your hosted zone ID
 aws route53 list-hosted-zones --query "HostedZones[?Name=='yourdomain.com.'].Id" --output text
 
@@ -238,8 +250,8 @@ chmod +x update-route53.sh
 # Test the script
 ./update-route53.sh
 
-# Set up cron job to run every 5 minutes
-echo "*/5 * * * * /home/$(whoami)/update-route53.sh >> /var/log/route53-update.log 2>&1" | crontab -
+# Set up cron job to run every 5 minutes on k8s-control node
+echo "*/5 * * * * /home/k8sadmin/update-route53.sh >> /var/log/route53-update.log 2>&1" | crontab -
 ```
 
 #### Create Wildcard DNS Record (Optional but Recommended)


### PR DESCRIPTION
## Summary
- Move AWS CLI installation and dynamic DNS cron job from development machine to k8s-control node
- Add comprehensive AWS CLI installation steps for the control node
- Update cron job configuration to use correct user paths
- Improve system reliability by running DNS updates from always-on cluster infrastructure

## Test plan
- [ ] Verify AWS CLI installation steps work on k8s-control node
- [ ] Test Route53 update script execution
- [ ] Confirm cron job runs successfully every 5 minutes
- [ ] Validate DNS records are updated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)