### PR TITLE
Remove SSH private key and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ./join_command
+k8s-cluster-admin


### PR DESCRIPTION
## Summary
- Remove accidentally committed SSH private key (`k8s-cluster-admin`) from tracking
- Add `k8s-cluster-admin` to `.gitignore` to prevent future commits
- Security fix to prevent accidental exposure of SSH credentials

## Test plan
- [x] Verify SSH key is removed from tracking
- [x] Verify SSH key is added to .gitignore
- [ ] After merge, verify sensitive data is removed from Git history

🤖 Generated with [Claude Code](https://claude.ai/code)